### PR TITLE
GraphQL Playground - variants support for query templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/warthog",
-  "version": "2.41.3",
+  "version": "2.41.4",
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
@@ -73,7 +73,7 @@
     "@types/prettier": "^1.18.3",
     "@types/shortid": "^0.0.29",
     "@types/ws": "^6.0.3",
-    "@apollographql/graphql-playground-react": "https://github.com/Joystream/graphql-playground/releases/download/joystream%401.7.28/graphql-playground-react-v1.7.28.tgz",
+    "@apollographql/graphql-playground-react": "https://github.com/Joystream/graphql-playground/releases/download/graphql-playground-react%401.7.29/graphql-playground-react-v1.7.29.tgz",
     "apollo-link-error": "^1.1.12",
     "apollo-link-http": "^1.5.16",
     "apollo-server": "^2.9.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,9 @@
   resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz#3ce939cb127fb8aaa3ffc1e90dff9b8af9f2e3dc"
   integrity sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ==
 
-"@apollographql/graphql-playground-react@https://github.com/Joystream/graphql-playground/releases/download/joystream%401.7.28/graphql-playground-react-v1.7.28.tgz":
-  version "1.7.28"
-  resolved "https://github.com/Joystream/graphql-playground/releases/download/joystream%401.7.28/graphql-playground-react-v1.7.28.tgz#24c9c54e14ae0ba13c894738b4b87301f5801b26"
+"@apollographql/graphql-playground-react@https://github.com/Joystream/graphql-playground/releases/download/graphql-playground-react%401.7.29/graphql-playground-react-v1.7.29.tgz":
+  version "1.7.29"
+  resolved "https://github.com/Joystream/graphql-playground/releases/download/graphql-playground-react%401.7.29/graphql-playground-react-v1.7.29.tgz#bf0bf4a72f74de156ccf2a8638e7cb617a8b41e2"
   dependencies:
     "@types/lru-cache" "^4.1.1"
     apollo-link "^1.2.13"


### PR DESCRIPTION
Variants support for query templates. Brings changes from https://github.com/Joystream/graphql-playground/pull/1 & https://github.com/Joystream/graphql-playground/pull/2 to Warthog.