### PR TITLE
allow JSONField to contain an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/warthog",
-  "version": "2.41.7",
+  "version": "2.41.8",
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/decorators/JSONField.ts
+++ b/src/decorators/JSONField.ts
@@ -10,6 +10,7 @@ interface JSONFieldOptions {
   nullable?: boolean;
   filter?: boolean;
   gqlFieldType?: ClassType;
+  array?: boolean;
 }
 
 export function JSONField(options: JSONFieldOptions = {}): any {


### PR DESCRIPTION
This PR allows marking of JSONField as an array. This is Warthog's part of fix for https://github.com/Joystream/hydra/issues/500.