### PR TITLE
changed BaseModel's createdAt & updatedAt field types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/warthog",
-  "version": "2.41.8",
+  "version": "2.41.9",
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/core/BaseModel.ts
+++ b/src/core/BaseModel.ts
@@ -3,10 +3,8 @@ import { Field, ID, Int, InterfaceType, ObjectType } from 'type-graphql';
 import {
   BeforeInsert,
   Column,
-  CreateDateColumn,
   PrimaryColumn,
   PrimaryGeneratedColumn,
-  UpdateDateColumn,
   VersionColumn,
 } from 'typeorm';
 
@@ -41,10 +39,10 @@ export abstract class BaseModel implements BaseGraphQLObject {
   @PrimaryColumn({ type: String })
   id!: IDType;
 
-  @CreateDateColumn() createdAt!: Date;
+  @Column() createdAt!: Date;
   @Column() createdById!: IDType;
 
-  @UpdateDateColumn({ nullable: true })
+  @Column({ nullable: true })
   updatedAt?: Date;
   @Column({ nullable: true })
   updatedById?: IDType;
@@ -82,10 +80,10 @@ export abstract class BaseModelUUID implements BaseGraphQLObject {
   @PrimaryGeneratedColumn('uuid')
   id!: IDType;
 
-  @CreateDateColumn() createdAt!: Date;
+  @Column() createdAt!: Date;
   @Column() createdById!: IDType;
 
-  @UpdateDateColumn({ nullable: true })
+  @Column({ nullable: true })
   updatedAt?: Date;
   @Column({ nullable: true })
   updatedById?: IDType;


### PR DESCRIPTION
This PR changes the ` createdAt` & `updatedAt` field types of **BaseModel** from `CreateDateColumn` & `UpdateDateColumn` to `Column`, respectively. Since, fields marked with `CreateDateColumn`/`UpdateDateColumn` are automatically populated whenever entity is created/updated, while for Query-Node we need `createdAt`/`updatedAt` fields to be populated based on the value of `blockTimestamp`