### PR TITLE
Add resolver timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ Almost all config in Warthog is driven by environment variables. The following i
 | WARTHOG_RESOLVERS_PATH        | Where should Warthog look for resolvers                  | src/\*\*\/\*.resolver.ts  |
 | WARTHOG_SUBSCRIPTIONS         | Should we enable subscriptions and open a websocket port | false                     |
 | WARTHOG_VALIDATE_RESOLVERS    | TypeGraphQL validation enabled?                          | false                     |
+| WARTHOG_RESOLVER_TIMEOUT_MS   | Highest time a resolver should take before timing out    | _none_                    |
+| WARTHOG_RELATION_CONCURRENCY  | Max number of relations a resolver can query in parallel | 30                        |
 
 ## Field/Column Decorators
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/warthog",
-  "version": "2.41.8",
+  "version": "2.41.9",
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
+  "engines": {
+    "node": ">=18"
+  },
   "bin": {
     "warthog": "bin/warthog"
   },
@@ -107,7 +110,7 @@
     "typedi": "^0.8.0",
     "typeorm": "https://github.com/Joystream/typeorm/releases/download/0.3.5/typeorm-v0.3.5.tgz",
     "typeorm-typedi-extensions": "^0.4.1",
-    "typescript": "^4.4"
+    "typescript": "^5.4.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/warthog",
-  "version": "2.41.9",
+  "version": "2.42.0",
   "description": "Opinionated set of tools for setting up GraphQL backed by TypeORM",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/core/BaseModel.ts
+++ b/src/core/BaseModel.ts
@@ -3,10 +3,8 @@ import { Field, ID, Int, InterfaceType, ObjectType } from 'type-graphql';
 import {
   BeforeInsert,
   Column,
-  CreateDateColumn,
   PrimaryColumn,
   PrimaryGeneratedColumn,
-  UpdateDateColumn,
   VersionColumn,
 } from 'typeorm';
 
@@ -41,10 +39,10 @@ export abstract class BaseModel implements BaseGraphQLObject {
   @PrimaryColumn({ type: String })
   id!: IDType;
 
-  @CreateDateColumn() createdAt!: Date;
+  @Column() createdAt!: Date;
   @Column() createdById!: IDType;
 
-  @UpdateDateColumn({ nullable: true })
+  @Column({ nullable: true })
   updatedAt?: Date;
   @Column({ nullable: true })
   updatedById?: IDType;
@@ -82,10 +80,10 @@ export abstract class BaseModelUUID implements BaseGraphQLObject {
   @PrimaryGeneratedColumn('uuid')
   id!: IDType;
 
-  @CreateDateColumn() createdAt!: Date;
+  @Column() createdAt!: Date;
   @Column() createdById!: IDType;
 
-  @UpdateDateColumn({ nullable: true })
+  @Column({ nullable: true })
   updatedAt?: Date;
   @Column({ nullable: true })
   updatedById?: IDType;

--- a/src/middleware/DataLoaderMiddleware.ts
+++ b/src/middleware/DataLoaderMiddleware.ts
@@ -15,6 +15,8 @@ export class DataLoaderMiddleware implements MiddlewareInterface<BaseContext> {
       };
 
       const reqTimeout = Number(process.env.WARTHOG_RESOLVER_TIMEOUT_MS);
+      const chunkSize = Number(process.env.WARTHOG_RELATION_CONCURRENCY) || 30;
+
       const abortSignal = reqTimeout ? AbortSignal.timeout(reqTimeout) : undefined;
 
       const loaders = context.dataLoader.loaders;
@@ -37,7 +39,6 @@ export class DataLoaderMiddleware implements MiddlewareInterface<BaseContext> {
                 throw new Error('You must flatten arrays of arrays of entities');
               }
 
-              const chunkSize = Number(process.env.WARTHOG_RELATION_CONCURRENCY) || 30;
               return chunk(entities, chunkSize).reduce<Promise<any[][]>>(
                 async (prev, entityChunk) => {
                   const next = await prev;

--- a/src/middleware/DataLoaderMiddleware.ts
+++ b/src/middleware/DataLoaderMiddleware.ts
@@ -1,12 +1,9 @@
 import * as DataLoader from 'dataloader';
+import { chunk } from 'lodash';
 import { MiddlewareInterface, NextFn, ResolverData } from 'type-graphql';
 import { Service } from 'typedi';
 
 import { BaseContext } from '../core';
-
-interface Deleteable {
-  deletedAt?: string;
-}
 
 @Service()
 export class DataLoaderMiddleware implements MiddlewareInterface<BaseContext> {
@@ -16,6 +13,9 @@ export class DataLoaderMiddleware implements MiddlewareInterface<BaseContext> {
         initialized: true,
         loaders: {},
       };
+
+      const reqTimeout = Number(process.env.WARTHOG_RESOLVER_TIMEOUT_MS);
+      const abortSignal = reqTimeout ? AbortSignal.timeout(reqTimeout) : undefined;
 
       const loaders = context.dataLoader.loaders;
 
@@ -36,18 +36,38 @@ export class DataLoaderMiddleware implements MiddlewareInterface<BaseContext> {
               if (Array.isArray(entities) && entities[0] && Array.isArray(entities[0])) {
                 throw new Error('You must flatten arrays of arrays of entities');
               }
-              return Promise.all(
-                entities.map((entity) => context.connection.relationLoader.load(relation, entity))
-              ).then(function (results) {
-                return results.map(function (related) {
-                  return relation.isManyToOne || relation.isOneToOne ? related[0] : related;
-                });
-              });
+
+              const chunkSize = Number(process.env.WARTHOG_RELATION_CONCURRENCY) || 30;
+              return chunk(entities, chunkSize).reduce<Promise<any[][]>>(
+                async (prev, entityChunk) => {
+                  const next = await prev;
+
+                  if (abortSignal?.aborted) {
+                    throw new Error('Resolver timed out');
+                  }
+
+                  const results = await Promise.all(
+                    entityChunk.map((entity) =>
+                      context.connection.relationLoader.load(relation, entity)
+                    )
+                  );
+
+                  next.push(
+                    ...results.map((related) =>
+                      relation.isManyToOne || relation.isOneToOne ? related[0] : related
+                    )
+                  );
+
+                  return next;
+                },
+                Promise.resolve([])
+              );
             });
           }
         });
       });
     }
+
     return next();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "5.0",
     "keyofStringsOnly": true,
     "lib": [
       "es2016",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11459,10 +11459,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^4.4:
-  version "4.5.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Address the part 2 of https://github.com/Joystream/joystream/issues/5088

It's a bit hacky but the only efficient way I found to really stop the resolvers (and not having queries still happening in the background) is through the DataLoader middleware. The main reason is that this middleware is responsible for the n+1 problem so other middlewares wouldn't be able to abort the queries the DataLoader initiate.

Also it has to split the relation queries into chunks instead of running everything in parallel (`WARTHOG_RELATION_CONCURRENCY` set the size of the chunk). It might affect the performance of slow queries but it could also free some db connection for other clients so overall I think it's not too bad.

I updated typescript in order to use `AbortSignal.timeout(reqTimeout)` because I couldn't figure out a way to clear timeout from the more traditional `setTimeout`, because `next()` resolves before the relations queries (which is weird because when running a middleware after this one it doesn't resolves until all fields have resolves :shrug:)

FYI I tested it with slow "horizontal" queries like `distributionBuckets(where: { id_eq: "0:1" }) { bags { objects { id }  }`  but also huge queries with a lot of depth. It does work in both case because even with the deeper queries the first resolvers dataloaders get's called for all deeper entities. However these deep queries will return some of the data it got before the timeout **and** and errors for every entities which timed out.